### PR TITLE
Update Prelude to reflect changes to `Natural` literals

### DIFF
--- a/Bool/fold
+++ b/Bool/fold
@@ -4,9 +4,9 @@
 Examples:
 
 ```
-./fold True Integer 0 1 = 0
+./fold True Natural 0 1 = 0
 
-./fold False Integer 0 1 = 1
+./fold False Natural 0 1 = 1
 ```
 -}
     let fold

--- a/Integer/show
+++ b/Integer/show
@@ -1,13 +1,14 @@
 {-
 Render an `Integer` as `Text` using the same representation as Dhall source
-code (i.e. a decimal number with a leading `-` sign if negative)
+code (i.e. a decimal number with a leading `-` sign if negative and a leading
+`+` sign if non-negative)
 
 Examples:
 
 ```
 ./show -3 = "-3"
 
-./show  0 =  "0"
+./show +0 = "+0"
 ```
 -}
 let show : Integer → Text = Integer/show in show

--- a/List/all
+++ b/List/all
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for all elements in the
 Examples:
 
 ```
-./all Natural Natural/even [ +2, +3, +5 ] = False
+./all Natural Natural/even [ 2, 3, 5 ] = False
 
 ./all Natural Natural/even ([] : List Natural) = True
 ```

--- a/List/any
+++ b/List/any
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for any element in the
 Examples:
 
 ```
-./any Natural Natural/even [ +2, +3, +5 ] = True
+./any Natural Natural/even [ 2, 3, 5 ] = True
 
 ./any Natural Natural/even ([] : List Natural) = False
 ```

--- a/List/concat
+++ b/List/concat
@@ -4,22 +4,22 @@ Concatenate a `List` of `List`s into a single `List`
 Examples:
 
 ```
-./concat Integer
+./concat Natural
 [   [0, 1, 2]
 ,   [3, 4]
 ,   [5, 6, 7, 8]
 ]
 = [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ]
 
-./concat Integer
-(   [   [] : List Integer
-    ,   [] : List Integer
-    ,   [] : List Integer
+./concat Natural
+(   [   [] : List Natural
+    ,   [] : List Natural
+    ,   [] : List Natural
     ]
 )
-= [] : List Integer
+= [] : List Natural
 
-./concat Integer ([] : List (List Integer)) = [] : List Integer
+./concat Natural ([] : List (List Natural)) = [] : List Natural
 ```
 -}
     let concat

--- a/List/concatMap
+++ b/List/concatMap
@@ -5,8 +5,8 @@ results
 Examples:
 
 ```
-./concatMap Natural Natural (λ(n : Natural) → [n, n]) [+2, +3, +5]
-= [ +2, +2, +3, +3, +5, +5 ]
+./concatMap Natural Natural (λ(n : Natural) → [n, n]) [2, 3, 5]
+= [ 2, 2, 3, 3, 5, 5 ]
 
 ./concatMap Natural Natural (λ(n : Natural) → [n, n]) ([] : List Natural)
 = [] : List Natural

--- a/List/filter
+++ b/List/filter
@@ -4,11 +4,11 @@ Only keep elements of the list where the supplied function returns `True`
 Examples:
 
 ```
-./filter Natural Natural/even [+2, +3, +5]
-= [ +2 ]
+./filter Natural Natural/even [ 2, 3, 5 ]
+= [ 2 ]
 
-./filter Natural Natural/odd [+2, +3, +5]
-= [ +3, +5 ]
+./filter Natural Natural/odd [ 2, 3, 5 ]
+= [ 3, 5 ]
 ```
 -}
     let filter

--- a/List/fold
+++ b/List/fold
@@ -9,29 +9,29 @@ Examples:
 ```
     ./fold
     Natural
-    [ +2, +3, +5 ]
+    [ 2, 3, 5 ]
     Natural
     (λ(x : Natural) → λ(y : Natural) → x + y)
-    +0
-=   +10
+    0
+=   10
 
     λ(nil : Natural)
 →   ./fold
     Natural
-    [ +2, +3, +5 ]
+    [ 2, 3, 5 ]
     Natural
     (λ(x : Natural) → λ(y : Natural) → x + y)
     nil
-=   λ(nil : Natural) → +2 + +3 + +5 + nil
+=   λ(nil : Natural) → 2 + 3 + 5 + nil
 
     λ(list : Type)
 →   λ(cons : Natural → list → list)
 →   λ(nil : list)
-→   ./fold Natural [ +2, +3, +5 ] list cons nil
+→   ./fold Natural [ 2, 3, 5 ] list cons nil
 =   λ(list : Type)
 →   λ(cons : Natural → list → list)
 →   λ(nil : list)
-→   cons +2 (cons +3 (cons +5 nil))
+→   cons 2 (cons 3 (cons 5 nil))
 ```
 -}
     let fold

--- a/List/generate
+++ b/List/generate
@@ -1,13 +1,13 @@
 {-
-Build a list by calling the supplied function on all `Natural` numbers from `+0`
+Build a list by calling the supplied function on all `Natural` numbers from `0`
 up to but not including the supplied `Natural` number
 
 Examples:
 
 ```
-./generate +5 Bool Natural/even = [ True, False, True, False, True ]
+./generate 5 Bool Natural/even = [ True, False, True, False, True ]
 
-./generate +0 Bool Natural/even = [] : List Bool
+./generate 0 Bool Natural/even = [] : List Bool
 ```
 -}
     let generate

--- a/List/head
+++ b/List/head
@@ -4,9 +4,9 @@ Retrieve the first element of the list
 Examples:
 
 ```
-./head Integer [ 0, 1, 2 ] = [ 0 ] : Optional Integer
+./head Natural [ 0, 1, 2 ] = [ 0 ] : Optional Natural
 
-./head Integer ([] : List Integer) = [] : Optional Integer
+./head Natural ([] : List Natural) = [] : Optional Natural
 ```
 -}
 let head : ∀(a : Type) → List a → Optional a = List/head in head

--- a/List/indexed
+++ b/List/indexed
@@ -5,9 +5,9 @@ Examples:
 
 ```
 ./indexed Bool [ True, False, True ]
-=   [   { index = +0, value = True  }
-    ,   { index = +1, value = False }
-    ,   { index = +2, value = True  }
+=   [   { index = 0, value = True  }
+    ,   { index = 1, value = False }
+    ,   { index = 2, value = True  }
     ] : List { index : Natural, value : Bool }
 
 ./indexed Bool ([] : List Bool)

--- a/List/iterate
+++ b/List/iterate
@@ -5,10 +5,10 @@ function
 Examples:
 
 ```
-./iterate +10 Natural (λ(x : Natural) → x * +2) +1
-= [ +1, +2, +4, +8, +16, +32, +64, +128, +256, +512 ]
+./iterate 10 Natural (λ(x : Natural) → x * 2) 1
+= [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
 
-./iterate +0 Natural (λ(x : Natural) → x * +2) +1
+./iterate 0 Natural (λ(x : Natural) → x * 2) 1
 = [] : List Natural
 ```
 -}

--- a/List/last
+++ b/List/last
@@ -4,9 +4,9 @@ Retrieve the last element of the list
 Examples:
 
 ```
-./last Integer [ 0, 1, 2 ] = [ 2 ] : Optional Integer
+./last Natural [ 0, 1, 2 ] = [ 2 ] : Optional Natural
 
-./last Integer ([] : List Integer) = [] : Optional Integer
+./last Natural ([] : List Natural) = [] : Optional Natural
 ```
 -}
 let last : ∀(a : Type) → List a → Optional a = List/last in last

--- a/List/length
+++ b/List/length
@@ -4,9 +4,9 @@ Returns the number of elements in a list
 Examples:
 
 ```
-./length Integer [ 0, 1, 2 ] = +3
+./length Natural [ 0, 1, 2 ] = 3
 
-./length Integer ([] : List Integer) = +0
+./length Natural ([] : List Natural) = 0
 ```
 -}
 let length : ∀(a : Type) → List a → Natural = List/length in length

--- a/List/map
+++ b/List/map
@@ -4,7 +4,7 @@ Transform a list by applying a function to each element
 Examples:
 
 ```
-./map Natural Bool Natural/even [ +2, +3, +5 ]
+./map Natural Bool Natural/even [ 2, 3, 5 ]
 = [ True, False, False ]
 
 ./map Natural Bool Natural/even ([] : List Natural)

--- a/List/null
+++ b/List/null
@@ -4,9 +4,9 @@ Returns `True` if the `List` is empty and `False` otherwise
 Examples:
 
 ```
-./null Integer [ 0, 1, 2 ] = False
+./null Natural [ 0, 1, 2 ] = False
 
-./null Integer ([] : List Integer) = True
+./null Natural ([] : List Natural) = True
 ```
 -}
     let null

--- a/List/replicate
+++ b/List/replicate
@@ -4,9 +4,9 @@ Build a list by copying the given element the specified number of times
 Examples:
 
 ```
-./replicate +9 Integer 1 = [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+./replicate 9 Natural 1 = [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 
-./replicate +0 Integer 1 = [] : List Integer
+./replicate 0 Natural 1 = [] : List Natural
 ```
 -}
     let replicate

--- a/List/reverse
+++ b/List/reverse
@@ -4,9 +4,9 @@ Reverse a list
 Examples:
 
 ```
-./reverse Integer [ 0, 1, 2 ] = [ 2, 1, 0 ] : List Integer
+./reverse Natural [ 0, 1, 2 ] = [ 2, 1, 0 ] : List Natural
 
-./reverse Integer ([] : List Integer) = [] : List Integer
+./reverse Natural ([] : List Natural) = [] : List Natural
 ```
 -}
 let reverse : ∀(a : Type) → List a → List a = List/reverse in reverse

--- a/List/shifted
+++ b/List/shifted
@@ -7,28 +7,28 @@ Examples:
 ```
 ./shifted
 Bool
-[   [   { index = +0, value = True  }
-    ,   { index = +1, value = True  }
-    ,   { index = +2, value = True  }
+[   [   { index = 0, value = True  }
+    ,   { index = 1, value = True  }
+    ,   { index = 2, value = True  }
     ]
-,   [   { index = +0, value = False }
-    ,   { index = +1, value = False }
+,   [   { index = 0, value = False }
+    ,   { index = 1, value = False }
     ]
-,   [   { index = +0, value = True  }
-    ,   { index = +1, value = True  }
-    ,   { index = +2, value = True  }
-    ,   { index = +3, value = True  }
+,   [   { index = 0, value = True  }
+    ,   { index = 1, value = True  }
+    ,   { index = 2, value = True  }
+    ,   { index = 3, value = True  }
     ]
 ]
-=   [   { index = +0, value = True  }
-    ,   { index = +1, value = True  }
-    ,   { index = +2, value = True  }
-    ,   { index = +3, value = False }
-    ,   { index = +4, value = False }
-    ,   { index = +5, value = True  }
-    ,   { index = +6, value = True  }
-    ,   { index = +7, value = True  }
-    ,   { index = +8, value = True  }
+=   [   { index = 0, value = True  }
+    ,   { index = 1, value = True  }
+    ,   { index = 2, value = True  }
+    ,   { index = 3, value = False }
+    ,   { index = 4, value = False }
+    ,   { index = 5, value = True  }
+    ,   { index = 6, value = True  }
+    ,   { index = 7, value = True  }
+    ,   { index = 8, value = True  }
     ]
 
 ./shifted Bool ([] : List (List { index : Natural, value : Bool }))
@@ -79,9 +79,9 @@ Bool
                                         (y.diff (n + length))
                                   }
                           )
-                          { count = +0, diff = λ(_ : Natural) → nil }
+                          { count = 0, diff = λ(_ : Natural) → nil }
                 
-                in  result.diff +0
+                in  result.diff 0
             )
 
 in  shifted

--- a/Natural/build
+++ b/Natural/build
@@ -10,7 +10,7 @@ Examples:
 →   λ(zero : natural)
 →   succ (succ (succ zero))
 )
-= +3
+= 3
 
 ./build
 (   λ(natural : Type)
@@ -18,7 +18,7 @@ Examples:
 →   λ(zero : natural)
 →   zero
 )
-= +0
+= 0
 ```
 -}
     let build

--- a/Natural/enumerate
+++ b/Natural/enumerate
@@ -1,13 +1,13 @@
 {-
-Generate a list of numbers from `+0` up to but not including the specified
+Generate a list of numbers from `0` up to but not including the specified
 number
 
 Examples:
 
 ```
-./enumerate +10 = [ +0, +1, +2, +3, +4, +5, +6, +7, +8, +9 ]
+./enumerate 10 = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
 
-./enumerate +0 = [] : List Natural
+./enumerate 0 = [] : List Natural
 ```
 -}
     let enumerate

--- a/Natural/even
+++ b/Natural/even
@@ -4,9 +4,9 @@ Returns `True` if a number if even and returns `False` otherwise
 Examples:
 
 ```
-./even +3 = False
+./even 3 = False
 
-./even +0 = True
+./even 0 = True
 ```
 -}
 let even : Natural → Bool = Natural/even in even

--- a/Natural/fold
+++ b/Natural/fold
@@ -1,21 +1,21 @@
 {-
 `fold` is the primitive function for consuming `Natural` numbers
 
-If you treat the number `+3` as `succ (succ (succ zero))` then a `fold` just
+If you treat the number `3` as `succ (succ (succ zero))` then a `fold` just
 replaces each `succ` and `zero` with something else
 
 Examples:
 
 ```
-./fold +3 Natural (λ(x : Natural) → +5 * x) +1 = +125
+./fold 3 Natural (λ(x : Natural) → 5 * x) 1 = 125
 
-λ(zero : Natural) → ./fold +3 Natural (λ(x : Natural) → +5 * x) zero
-= λ(zero : Natural) → +5 * +5 * +5 * zero
+λ(zero : Natural) → ./fold 3 Natural (λ(x : Natural) → 5 * x) zero
+= λ(zero : Natural) → 5 * 5 * 5 * zero
 
     λ(natural : Type)
 →   λ(succ : natural → natural)
 →   λ(zero : natural)
-→   ./fold +3 natural succ zero
+→   ./fold 3 natural succ zero
 =   λ(natural : Type)
 →   λ(succ : natural → natural)
 →   λ(zero : natural)

--- a/Natural/isZero
+++ b/Natural/isZero
@@ -1,12 +1,12 @@
 {-
-Returns `True` if a number is `+0` and returns `False` otherwise
+Returns `True` if a number is `0` and returns `False` otherwise
 
 Examples:
 
 ```
-./isZero +2 = False
+./isZero 2 = False
 
-./isZero +0 = True
+./isZero 0 = True
 ```
 -}
 let isZero : Natural → Bool = Natural/isZero in isZero

--- a/Natural/odd
+++ b/Natural/odd
@@ -4,9 +4,9 @@ Returns `True` if a number is odd and returns `False` otherwise
 Examples:
 
 ```
-./odd +3 = True
+./odd 3 = True
 
-./odd +0 = False
+./odd 0 = False
 ```
 -}
 let odd : Natural → Bool = Natural/odd in odd

--- a/Natural/product
+++ b/Natural/product
@@ -4,9 +4,9 @@ Multiply all the numbers in a `List`
 Examples:
 
 ```
-./product [ +2, +3, +5 ] = +30
+./product [ 2, 3, 5 ] = 30
 
-./product ([] : List Natural) = +1
+./product ([] : List Natural) = 1
 ```
 -}
     let product
@@ -17,6 +17,6 @@ Examples:
             xs
             Natural
             (λ(l : Natural) → λ(r : Natural) → l * r)
-            +1
+            1
 
 in  product

--- a/Natural/show
+++ b/Natural/show
@@ -1,13 +1,13 @@
 {-
 Render a `Natural` number as `Text` using the same representation as Dhall
-source code (i.e. a decimal number with a leading `+` sign)
+source code (i.e. a decimal number)
 
 Examples:
 
 ```
-./show +3 = "+3"
+./show 3 = "3"
 
-./show +0 = "+0"
+./show 0 = "0"
 ```
 -}
 let show : Natural → Text = Natural/show in show

--- a/Natural/sum
+++ b/Natural/sum
@@ -4,9 +4,9 @@ Add all the numbers in a `List`
 Examples:
 
 ```
-./sum [ +2, +3, +5 ] = +10
+./sum [ 2, 3, 5 ] = 10
 
-./sum ([] : List Natural) = +0
+./sum ([] : List Natural) = 0
 ```
 -}
     let sum
@@ -17,6 +17,6 @@ Examples:
             xs
             Natural
             (λ(l : Natural) → λ(r : Natural) → l + r)
-            +0
+            0
 
 in  sum

--- a/Natural/toInteger
+++ b/Natural/toInteger
@@ -4,9 +4,9 @@ Convert a `Natural` number to the corresponding `Integer`
 Examples:
 
 ```
-./toInteger +3 = 3
+./toInteger 3 = +3
 
-./toInteger +0 = 0
+./toInteger 0 = +0
 ```
 -}
 let toInteger : Natural → Integer = Natural/toInteger in toInteger

--- a/Optional/all
+++ b/Optional/all
@@ -5,7 +5,7 @@ and `True` otherwise:
 Examples:
 
 ```
-./all Natural Natural/even ([ +3 ] : Optional Natural) = False
+./all Natural Natural/even ([ 3 ] : Optional Natural) = False
 
 ./all Natural Natural/even ([] : Optional Natural) = True
 ```

--- a/Optional/any
+++ b/Optional/any
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for a present element and
 Examples:
 
 ```
-./any Natural Natural/even ([ +2 ] : Optional Natural) = True
+./any Natural Natural/even ([ 2 ] : Optional Natural) = True
 
 ./any Natural Natural/even ([] : Optional Natural) = False
 ```

--- a/Optional/build
+++ b/Optional/build
@@ -5,22 +5,22 @@ Examples:
 
 ```
 ./build
-Integer
+Natural
 (   λ(optional : Type)
-→   λ(just : Integer → optional)
+→   λ(just : Natural → optional)
 →   λ(nothing : optional)
 →   just 1
 )
-= [ 1 ] : Optional Integer
+= [ 1 ] : Optional Natural
 
 ./build
-Integer
+Natural
 (   λ(optional : Type)
-→   λ(just : Integer → optional)
+→   λ(just : Natural → optional)
 →   λ(nothing : optional)
 →   nothing
 )
-= [] : Optional Integer
+= [] : Optional Natural
 ```
 -}
     let build

--- a/Optional/concat
+++ b/Optional/concat
@@ -4,14 +4,14 @@ Flatten two `Optional` layers into a single `Optional` layer
 Examples:
 
 ```
-./concat Integer ([ [ 1 ] : Optional Integer ] : Optional (Optional Integer))
-= [ 1 ] : Optional Integer
+./concat Natural ([ [ 1 ] : Optional Natural ] : Optional (Optional Natural))
+= [ 1 ] : Optional Natural
 
-./concat Integer ([ [] : Optional Integer ] : Optional (Optional Integer))
-= [] : Optional Integer
+./concat Natural ([ [] : Optional Natural ] : Optional (Optional Natural))
+= [] : Optional Natural
 
-./concat Integer ([] : Optional (Optional Integer))
-= [] : Optional Integer
+./concat Natural ([] : Optional (Optional Natural))
+= [] : Optional Natural
 ```
 -}
     let concat

--- a/Optional/filter
+++ b/Optional/filter
@@ -4,10 +4,10 @@ Only keep an `Optional` element if the supplied function returns `True`
 Examples:
 
 ```
-./filter Natural Natural/even ([ +2 ] : Optional Natural)
-= [ +2 ] : Optional Natural
+./filter Natural Natural/even ([ 2 ] : Optional Natural)
+= [ 2 ] : Optional Natural
 
-./filter Natural Natural/odd ([ +2 ] : Optional Natural)
+./filter Natural Natural/odd ([ 2 ] : Optional Natural)
 = [] : Optional Natural
 ```
 -}

--- a/Optional/fold
+++ b/Optional/fold
@@ -4,9 +4,9 @@
 Examples:
 
 ```
-./fold Integer ([ 2 ] : Optional Integer) Integer (λ(x : Integer) → x) 0 = 2
+./fold Natural ([ 2 ] : Optional Natural) Natural (λ(x : Natural) → x) 0 = 2
 
-./fold Integer ([] : Optional Integer) Integer (λ(x : Integer) → x) 0 = 0
+./fold Natural ([] : Optional Natural) Natural (λ(x : Natural) → x) 0 = 0
 ```
 -}
     let fold

--- a/Optional/head
+++ b/Optional/head
@@ -5,20 +5,20 @@ Examples:
 
 ```
 ./head
-Integer
-[ [   ] : Optional Integer
-, [ 1 ] : Optional Integer
-, [ 2 ] : Optional Integer
+Natural
+[ [   ] : Optional Natural
+, [ 1 ] : Optional Natural
+, [ 2 ] : Optional Natural
 ]
-= [ 1 ] : Optional Integer
+= [ 1 ] : Optional Natural
 
 ./head
-Integer
-[ [] : Optional Integer, [] : Optional Integer ]
-= [] : Optional Integer
+Natural
+[ [] : Optional Natural, [] : Optional Natural ]
+= [] : Optional Natural
 
-./head Integer ([] : List (Optional Integer))
-= [] : Optional Integer
+./head Natural ([] : List (Optional Natural))
+= [] : Optional Natural
 ```
 -}
     let head

--- a/Optional/last
+++ b/Optional/last
@@ -5,20 +5,20 @@ Examples:
 
 ```
 ./last
-Integer
-[ [   ] : Optional Integer
-, [ 1 ] : Optional Integer
-, [ 2 ] : Optional Integer
+Natural
+[ [   ] : Optional Natural
+, [ 1 ] : Optional Natural
+, [ 2 ] : Optional Natural
 ]
-= [ 2 ] : Optional Integer
+= [ 2 ] : Optional Natural
 
 ./last
-Integer
-[ [] : Optional Integer, [] : Optional Integer ]
-= [] : Optional Integer
+Natural
+[ [] : Optional Natural, [] : Optional Natural ]
+= [] : Optional Natural
 
-./last Integer ([] : List (Optional Integer))
-= [] : Optional Integer
+./last Natural ([] : List (Optional Natural))
+= [] : Optional Natural
 ```
 -}
     let last

--- a/Optional/length
+++ b/Optional/length
@@ -1,18 +1,18 @@
 {-
-Returns `+1` if the `Optional` value is present and `+0` if the value is absent
+Returns `1` if the `Optional` value is present and `0` if the value is absent
 
 Examples:
 
 ```
-./length Integer ([ 2 ] : Optional Integer) = +1
+./length Natural ([ 2 ] : Optional Natural) = 1
 
-./length Integer ([] : Optional Integer) = +0
+./length Natural ([] : Optional Natural) = 0
 ```
 -}
     let length
         : ∀(a : Type) → Optional a → Natural
         =   λ(a : Type)
           → λ(xs : Optional a)
-          → Optional/fold a xs Natural (λ(_ : a) → +1) +0
+          → Optional/fold a xs Natural (λ(_ : a) → 1) 0
 
 in  length

--- a/Optional/map
+++ b/Optional/map
@@ -4,7 +4,7 @@ Transform an `Optional` value with a function
 Examples:
 
 ```
-./map Natural Bool Natural/even ([ +3 ] : Optional Natural)
+./map Natural Bool Natural/even ([ 3 ] : Optional Natural)
 = [ False ] : Optional Bool
 
 ./map Natural Bool Natural/even ([] : Optional Natural)

--- a/Optional/null
+++ b/Optional/null
@@ -4,9 +4,9 @@ Returns `True` if the `Optional` value is absent and `False` if present
 Examples:
 
 ```
-./null Integer ([ 2 ] : Optional Integer) = False
+./null Natural ([ 2 ] : Optional Natural) = False
 
-./null Integer ([] : Optional Integer) = True
+./null Natural ([] : Optional Natural) = True
 ```
 -}
     let null

--- a/Optional/toList
+++ b/Optional/toList
@@ -4,9 +4,9 @@ Convert an `Optional` value into the equivalent `List`
 Examples:
 
 ```
-./toList Integer ([ 1 ] : Optional Integer) = [ 1 ]
+./toList Natural ([ 1 ] : Optional Natural) = [ 1 ]
 
-./toList Integer ([] : Optional Integer) = [] : List Integer
+./toList Natural ([] : Optional Natural) = [] : List Natural
 ```
 -}
     let toList

--- a/Text/concatMap
+++ b/Text/concatMap
@@ -4,10 +4,10 @@ Transform each value in a `List` into `Text` and concatenate the result
 Examples:
 
 ```
-./concatMap Integer (λ(n : Integer) → "${Integer/show n} ") [ 0, 1, 2 ]
+./concatMap Natural (λ(n : Natural) → "${Natural/show n} ") [ 0, 1, 2 ]
 = "0 1 2 "
 
-./concatMap Integer (λ(n : Integer) → "${Integer/show n} ") ([] : List Integer)
+./concatMap Natural (λ(n : Natural) → "${Natural/show n} ") ([] : List Natural)
 = ""
 ```
 -}

--- a/Text/concatMapSep
+++ b/Text/concatMapSep
@@ -5,9 +5,9 @@ separator in between each value
 Examples:
 
 ```
-./concatMapSep ", " Integer Integer/show [ 0, 1, 2 ] = "0, 1, 2"
+./concatMapSep ", " Natural Natural/show [ 0, 1, 2 ] = "0, 1, 2"
 
-./concatMapSep ", " Integer Integer/show ([] : List Integer) = ""
+./concatMapSep ", " Natural Natural/show ([] : List Natural) = ""
 ```
 -}
     let concatMapSep


### PR DESCRIPTION
The Prelude examples and code now reflect the fact that `Natural`
numbers don't require a leading `+`

Most of the examples change to use `Natural` literals since they are now
the more visually pleasing literal