### PR TITLE
Add utilities for working with `dhall-json`

### DIFF
--- a/JSON/Nesting
+++ b/JSON/Nesting
@@ -1,0 +1,32 @@
+{-
+This type is used as part of `dhall-json`'s support for preserving alternative
+names
+
+For example, this Dhall code:
+
+```
+    let Example = < Left : { foo : Natural } | Right : { bar : Bool } >
+
+in  let example = constructors Example
+
+in  let Nesting = < Inline : {} | Nested : Text >
+
+in  let nesting = constructors Nesting
+
+in  { field    = "name"
+    , nesting  = nesting.Inline {=}
+    , contents = example.Left { foo = 2 }
+    }
+```
+
+... generates this JSON:
+
+```
+{
+  "foo": 2,
+  "name": "Left"
+ }
+```
+
+-}
+let Nesting : Type = < Inline : {} | Nested : Text > in Nesting

--- a/JSON/Tagged
+++ b/JSON/Tagged
@@ -1,0 +1,69 @@
+{-
+This is a convenient type-level function when using `dhall-to-json`'s support
+for preserving alternative names
+
+For example, this code:
+
+```
+    let map = ../List/map
+
+in  let Provisioner =
+          < shell :
+              { inline : List Text }
+          | file :
+              { source : Text, destination : Text }
+          >
+
+in  let provisioner = constructors Provisioner
+
+in  let Tagged = ./Tagged
+
+in  let nesting = constructors ./Nesting
+
+in  let wrap
+        : Provisioner → Tagged Provisioner
+        =   λ(x : Provisioner)
+          → { field = "type", nesting = nesting.Nested "params", contents = x }
+
+in  { provisioners =
+        map
+        Provisioner
+        (Tagged Provisioner)
+        wrap
+        [ provisioner.shell { inline = [ "echo foo" ] }
+        , provisioner.file
+          { source = "app.tar.gz", destination = "/tmp/app.tar.gz" }
+        ]
+    }
+```
+
+... produces this JSON:
+
+```
+{
+  "provisioners": [
+    {
+      "params": {
+        "inline": [
+          "echo foo"
+        ]
+      },
+      "type": "shell"
+    },
+    {
+      "params": {
+        "destination": "/tmp/app.tar.gz",
+        "source": "app.tar.gz"
+      },
+      "type": "file"
+    }
+  ]
+}
+```
+
+-}
+    let Tagged
+        : Type → Type
+        = λ(a : Type) → { field : Text, nesting : ./Nesting , contents : a }
+
+in  Tagged


### PR DESCRIPTION
https://github.com/dhall-lang/dhall-json/issues/32 added `dhall-json`
support for preserving the alternative names for unions when converting
to JSON.  This adds two types to the Prelude to make working with this
feature more convenient