### PR TITLE
Add `{Integer,Natural}/toDouble`

### DIFF
--- a/Integer/toDouble
+++ b/Integer/toDouble
@@ -1,0 +1,12 @@
+{-
+Convert an `Integer` to the corresponding `Double`
+
+Examples:
+
+```
+./toDouble -3 = -3.0
+
+./toDouble +2 = 2.0
+```
+-}
+let toDouble : Integer → Double = Integer/toDouble in toDouble

--- a/Natural/toDouble
+++ b/Natural/toDouble
@@ -1,0 +1,16 @@
+{-
+Convert a `Natural` number to the corresponding `Double`
+
+Examples:
+
+```
+./toDouble 3 = 3.0
+
+./toDouble 0 = 0.0
+```
+-}
+    let toDouble
+        : Natural → Double
+        = λ(n : Natural) → Integer/toDouble (Natural/toInteger n)
+
+in  toDouble


### PR DESCRIPTION
I had forgotten to mirror these to the official Prelude when I added them to
the Prelude used by the Haskell implementation