### PR TITLE
Parenthesize right-associative output

### DIFF
--- a/List/fold
+++ b/List/fold
@@ -22,7 +22,7 @@ Examples:
     Natural
     (λ(x : Natural) → λ(y : Natural) → x + y)
     nil
-=   λ(nil : Natural) → 2 + 3 + 5 + nil
+=   λ(nil : Natural) → 2 + (3 + (5 + nil))
 
     λ(list : Type)
 →   λ(cons : Natural → list → list)

--- a/Natural/fold
+++ b/Natural/fold
@@ -10,7 +10,7 @@ Examples:
 ./fold 3 Natural (λ(x : Natural) → 5 * x) 1 = 125
 
 λ(zero : Natural) → ./fold 3 Natural (λ(x : Natural) → 5 * x) zero
-= λ(zero : Natural) → 5 * 5 * 5 * zero
+= λ(zero : Natural) → 5 * (5 * (5 * zero))
 
     λ(natural : Type)
 →   λ(succ : natural → natural)


### PR DESCRIPTION
This is related to https://github.com/dhall-lang/dhall-lang/pull/233

Specifically, `List/fold` and `Natural/fold` produce right-associated operators,
so the output must now be explicitly parenthesized since the default
associativity is specified to be left-associativity